### PR TITLE
Fixes potential issue in admin credential generation

### DIFF
--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -218,7 +218,6 @@ class OpenemrEcsStack(Stack):
             self,
             "Password",
             generate_secret_string=secretsmanager.SecretStringGenerator(
-                exclude_punctuation=True,
                 include_space=False,
                 secret_string_template='{"username": "admin"}',
                 generate_string_key="password"


### PR DESCRIPTION
It's possible to end up with a password that doesn't have a number in which case it won't satisfy the minimum password requirements and cause issues. This change fixes that by ensuring that we always have at least 3 out of 4 of the following; a lowercase character, a number, an uppercase character, and a special character.
