### PR TITLE
Updates to v7.0.3, updates to EMR serverless and the MySQL engine, and bugfix to admin credential

### DIFF
--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -48,9 +48,9 @@ class OpenemrEcsStack(Stack):
         self.valkey_port = 6379
         self.container_port = 443
         self.number_of_days_to_regenerate_ssl_materials = 2
-        self.emr_serverless_release_label = "emr-7.5.0"
-        self.aurora_mysql_engine_version = rds.AuroraMysqlEngineVersion.VER_3_08_0
-        self.openemr_version = "7.0.2"
+        self.emr_serverless_release_label = "emr-7.8.0"
+        self.aurora_mysql_engine_version = rds.AuroraMysqlEngineVersion.VER_3_08_1
+        self.openemr_version = "7.0.3"
         self.lambda_python_runtime = _lambda.Runtime.PYTHON_3_13
 
         # build infrastructure
@@ -218,7 +218,6 @@ class OpenemrEcsStack(Stack):
             self,
             "Password",
             generate_secret_string=secretsmanager.SecretStringGenerator(
-                exclude_punctuation=True,
                 include_space=False,
                 secret_string_template='{"username": "admin"}',
                 generate_string_key="password"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.171.0
+aws-cdk-lib==2.184.1
 constructs==10.3.0
 cdk-nag==2.27.223
 requests==2.32.0


### PR DESCRIPTION
Updates the EMR serverless release label to 7.8.0 and the MySQL Aurora Engine to 3.08.1.

Also fixes a potential issue that can occur with Admin credential generation.

Updates OpenEMR version to v7.0.3!