### PR TITLE
Upgrades and Password Generation Future Proofing

### DIFF
--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -391,14 +391,14 @@ class OpenemrEcsStack(Stack):
                             scope=self,
                             id="portal-onsite-two-address",
                             parameter_name="portal_onsite_two_address",
-                            string_value='https://' + self.alb.dns_name + '/portal/'
+                            string_value='https://' + self.alb.load_balancer_dns_name + '/portal/'
                         )
                     else:
                         self.portal_onsite_two_address = ssm.StringParameter(
                             scope=self,
                             id="portal-onsite-two-address",
                             parameter_name="portal_onsite_two_address",
-                            string_value='https://' + self.alb.dns_name + '/portal/'
+                            string_value='https://' + self.alb.load_balancer_dns_name + '/portal/'
                         )
 
             # Other parameters

--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -36,6 +36,7 @@ from aws_cdk import (
 )
 from constructs import Construct
 import hashlib
+import string
 
 class OpenemrEcsStack(Stack):
 

--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -48,8 +48,8 @@ class OpenemrEcsStack(Stack):
         self.valkey_port = 6379
         self.container_port = 443
         self.number_of_days_to_regenerate_ssl_materials = 2
-        self.emr_serverless_release_label = "emr-7.8.0"
-        self.aurora_mysql_engine_version = rds.AuroraMysqlEngineVersion.VER_3_08_1
+        self.emr_serverless_release_label = "emr-7.9.0"
+        self.aurora_mysql_engine_version = rds.AuroraMysqlEngineVersion.VER_3_09_0
         self.openemr_version = "7.0.3"
         self.lambda_python_runtime = _lambda.Runtime.PYTHON_3_13
 

--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -985,7 +985,7 @@ class OpenemrEcsStack(Stack):
             # Create cluster
             self.ecs_cluster = ecs.Cluster(self, "ecs-cluster",
                                            vpc=self.vpc,
-                                           container_insights=True,
+                                           container_insights_v2=ecs.ContainerInsights.ENHANCED,
                                            enable_fargate_capacity_providers=True,
                                            execute_command_configuration=ecs.ExecuteCommandConfiguration(
                                                kms_key=self.kms_key,

--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -215,9 +215,6 @@ class OpenemrEcsStack(Stack):
 
     def _create_password(self):
 
-        # Choose a random length between 16 and 32 (inclusive)
-        pw_length = random.randint(16, 32)
-
         # Keep only these very safe special characters available for passwords.
         safe_specials = "@%+=_."
 
@@ -232,8 +229,8 @@ class OpenemrEcsStack(Stack):
                 secret_string_template='{"username":"admin"}',
                 generate_string_key="password",
 
-                # Randomized length between 16 and 24
-                password_length=pw_length,
+                # Password is 32 characters long
+                password_length=32,
 
                 # No spaces as these can cause errors
                 include_space=False,

--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -217,7 +217,7 @@ class OpenemrEcsStack(Stack):
     def _create_password(self):
 
         # Keep only these very safe special characters available for passwords.
-        safe_specials = "@+="
+        safe_specials = "!()<>^{}~"
 
         # Exclude every other punctuation character (shell/JSON troublemakers and others that could cause bugs).
         # string.punctuation is: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
@@ -230,8 +230,8 @@ class OpenemrEcsStack(Stack):
                 secret_string_template='{"username":"admin"}',
                 generate_string_key="password",
 
-                # Password is 32 characters long
-                password_length=32,
+                # Password is 16 characters long
+                password_length=16,
 
                 # No spaces as these can cause errors
                 include_space=False,

--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -216,9 +216,9 @@ class OpenemrEcsStack(Stack):
     def _create_password(self):
 
         # Keep only these very safe special characters available for passwords.
-        safe_specials = "@%+=_."
+        safe_specials = "@+="
 
-        # Exclude every other punctuation character (shell/JSON troublemakers).
+        # Exclude every other punctuation character (shell/JSON troublemakers and others that could cause bugs).
         # string.punctuation is: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
         exclude_chars = ''.join(ch for ch in string.punctuation if ch not in safe_specials)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.184.1
+aws-cdk-lib==2.208.0
 constructs==10.3.0
 cdk-nag==2.27.223
 requests==2.32.4


### PR DESCRIPTION
- Upgraded EMR release label to v7.9.0 (https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-790-release.html)
- Upgraded MySQL Aurora to v3.09 (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.3090.html) 
- Updated AWS CDK version to v2.208.0 and changed how the ALB DNS name was referenced to avoid using the deprecated and soon to be removed older parameter.
- Fixed bug that would occasionally cause the architecture to create a non-usable admin password. 

Version 3.10 of the Aurora MySQL engine was just released (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.3100.html) and among other things this allows the database to autoscale up to 256 TB as opposed to the previous 128 TBs allowed. Once there's support added to the AWS Python CDK for it I'll test and update the new engine version and open another PR. 